### PR TITLE
Speed in duration or in px-per-sec options

### DIFF
--- a/captain_arro/generators/base.py
+++ b/captain_arro/generators/base.py
@@ -32,13 +32,12 @@ class AnimatedArrowGeneratorBase(ABC):
         
         # Speed options validation - only one can be defined
         speed_options_defined = sum([
-            speed != 20.0,  # Check if speed was explicitly set (not default)
             speed_in_px_per_second is not None,
             speed_in_duration_seconds is not None
         ])
         
         if speed_options_defined > 1:
-            raise ValueError("Only one speed option can be defined: speed, speed_in_px_per_second, or speed_in_duration_seconds")
+            raise ValueError("Only one speed option can be defined: speed_in_px_per_second or speed_in_duration_seconds")
         
         # Set speed based on provided option
         if speed_in_px_per_second is not None:

--- a/captain_arro/generators/base.py
+++ b/captain_arro/generators/base.py
@@ -19,10 +19,9 @@ class AnimatedArrowGeneratorBase(ABC):
         stroke_width: int = 10,
         width: int = 100,
         height: int = 100,
-        speed: float = 20.0,
+        speed_in_px_per_second: float = None,
+        speed_in_duration_seconds: float = None,
         num_arrows: int = 4,
-        speed_in_px_per_second: Optional[float] = None,
-        speed_in_duration_seconds: Optional[float] = None,
     ):
         self.color = color
         self.width = width
@@ -30,24 +29,14 @@ class AnimatedArrowGeneratorBase(ABC):
         self.num_arrows = max(1, num_arrows)
         self.stroke_width = max(2, stroke_width)
         
-        # Speed options validation - only one can be defined
-        speed_options_defined = sum([
-            speed_in_px_per_second is not None,
-            speed_in_duration_seconds is not None
-        ])
-        
-        if speed_options_defined > 1:
+        if (speed_in_duration_seconds is None) and (speed_in_duration_seconds is None):
+            raise ValueError("One speed option must be defined: speed_in_px_per_second or speed_in_duration_seconds")
+        if (speed_in_duration_seconds is not None) and (speed_in_duration_seconds is not None):
             raise ValueError("Only one speed option can be defined: speed_in_px_per_second or speed_in_duration_seconds")
-        
-        # Set speed based on provided option
-        if speed_in_px_per_second is not None:
-            self.speed = speed_in_px_per_second
-        elif speed_in_duration_seconds is not None:
-            self.speed_in_duration_seconds = speed_in_duration_seconds
-            self.speed = None  # Will be calculated dynamically
-        else:
-            self.speed = speed
-    
+
+        self.speed_in_px_per_second = speed_in_px_per_second
+        self.speed_in_duration_seconds = speed_in_duration_seconds or self._calculate_animation_duration()
+
     @abstractmethod
     def _generate_arrow_elements(self) -> str:
         """Generate the arrow elements for the SVG."""
@@ -65,12 +54,11 @@ class AnimatedArrowGeneratorBase(ABC):
     
     def _calculate_animation_duration(self) -> float:
         """Calculate the appropriate animation duration based on speed options."""
-        if hasattr(self, 'speed_in_duration_seconds') and self.speed_in_duration_seconds is not None:
+        if self.speed_in_duration_seconds is not None:
             return self.speed_in_duration_seconds
         else:
-            # Use speed in pixels per second
             transform_distance = self._get_transform_distance()
-            return transform_distance / self.speed
+            return transform_distance / self.speed_in_px_per_second
     
     def generate_svg(self) -> str:
         """Generate the complete SVG string."""

--- a/captain_arro/generators/flow/moving_flow_arrow_generator.py
+++ b/captain_arro/generators/flow/moving_flow_arrow_generator.py
@@ -9,28 +9,26 @@ class MovingFlowArrowGenerator(AnimatedArrowGeneratorBase):
             stroke_width: int = 15,
             width: int = 100,
             height: int = 100,
-            speed: float = 20.0,  # pixels_per_second
+            speed_in_px_per_second: float = 20.0,
+            speed_in_duration_seconds: float = None,
             direction: FLOW_DIRECTIONS = "right",
             num_arrows: int = 4,
             animation: ANIMATION_TYPES = "ease-in-out",
-            speed_in_px_per_second: float = None,
-            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
             stroke_width=stroke_width,
             width=width,
             height=height,
-            speed=speed,
-            num_arrows=num_arrows,
             speed_in_px_per_second=speed_in_px_per_second,
-            speed_in_duration_seconds=speed_in_duration_seconds
+            speed_in_duration_seconds=speed_in_duration_seconds,
+            num_arrows=num_arrows,
         )
         self.direction = direction.lower()
         self.animation = animation
 
     def _generate_arrow_classes(self) -> str:
-        duration = self._calculate_animation_duration()
+        duration = self.speed_in_duration_seconds
         classes = []
         for i in range(1, self.num_arrows + 1):
             classes.append(
@@ -39,7 +37,7 @@ class MovingFlowArrowGenerator(AnimatedArrowGeneratorBase):
 
     def _generate_arrow_elements(self) -> str:
         arrow_points = self._get_arrow_points()
-        duration = self._calculate_animation_duration()
+        duration = self.speed_in_duration_seconds
         elements = []
 
         for i in range(1, self.num_arrows + 1):

--- a/captain_arro/generators/flow/moving_flow_arrow_generator.py
+++ b/captain_arro/generators/flow/moving_flow_arrow_generator.py
@@ -13,6 +13,8 @@ class MovingFlowArrowGenerator(AnimatedArrowGeneratorBase):
             direction: FLOW_DIRECTIONS = "right",
             num_arrows: int = 4,
             animation: ANIMATION_TYPES = "ease-in-out",
+            speed_in_px_per_second: float = None,
+            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
@@ -20,7 +22,9 @@ class MovingFlowArrowGenerator(AnimatedArrowGeneratorBase):
             width=width,
             height=height,
             speed=speed,
-            num_arrows=num_arrows
+            num_arrows=num_arrows,
+            speed_in_px_per_second=speed_in_px_per_second,
+            speed_in_duration_seconds=speed_in_duration_seconds
         )
         self.direction = direction.lower()
         self.animation = animation
@@ -76,19 +80,14 @@ class MovingFlowArrowGenerator(AnimatedArrowGeneratorBase):
         else:
             raise ValueError(f"Invalid direction: {self.direction}. Use 'up', 'down', 'left', or 'right'.")
 
-    def _get_transform_distance(self) -> int:
+    def _get_transform_distance(self) -> float:
         if self.direction in ["up", "down"]:
-            return self.height // 2
+            return float(self.height // 2 * 2)  # Total distance for moving flow
         else:
-            return self.width // 2
-
-    def _calculate_animation_duration(self) -> float:
-        transform_distance = self._get_transform_distance()
-        total_distance = 2 * transform_distance
-        return total_distance / self.speed
+            return float(self.width // 2 * 2)  # Total distance for moving flow
 
     def _generate_animations(self) -> str:
-        distance = self._get_transform_distance()
+        distance = self._get_transform_distance() // 2  # Half distance for start/end positions
 
         if self.direction == "down":
             start_transform = f"translateY(-{distance}px)"

--- a/captain_arro/generators/flow/spotlight_flow_arrow_generator.py
+++ b/captain_arro/generators/flow/spotlight_flow_arrow_generator.py
@@ -9,24 +9,22 @@ class SpotlightFlowArrowGenerator(AnimatedArrowGeneratorBase):
             stroke_width: int = 10,
             width: int = 100,
             height: int = 100,
-            speed: float = 20.0,  # pixels_per_second
+            speed_in_px_per_second: float = 20.0,
+            speed_in_duration_seconds: float = None,
             direction: FLOW_DIRECTIONS = "right",
             num_arrows: int = 3,
             spotlight_size: float = 0.3,
             spotlight_path_extension_factor: float = 0.5,
             dim_opacity: float = 0.2,
-            speed_in_px_per_second: float = None,
-            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
             stroke_width=stroke_width,
             width=width,
             height=height,
-            speed=speed,
-            num_arrows=num_arrows,
             speed_in_px_per_second=speed_in_px_per_second,
-            speed_in_duration_seconds=speed_in_duration_seconds
+            speed_in_duration_seconds=speed_in_duration_seconds,
+            num_arrows=num_arrows,
         )
         self.direction = direction.lower()
         self.spotlight_size = max(0.1, min(1.0, spotlight_size))
@@ -68,7 +66,7 @@ class SpotlightFlowArrowGenerator(AnimatedArrowGeneratorBase):
         """
 
     def _generate_gradient_defs(self) -> str:
-        duration = self._calculate_animation_duration()
+        duration = self.speed_in_duration_seconds
 
         if self.direction in ["up", "down"]:
             gradient_attrs = f'x1="0" y1="0" x2="0" y2="{self.height}" gradientUnits="userSpaceOnUse"'

--- a/captain_arro/generators/flow/spotlight_flow_arrow_generator.py
+++ b/captain_arro/generators/flow/spotlight_flow_arrow_generator.py
@@ -15,6 +15,8 @@ class SpotlightFlowArrowGenerator(AnimatedArrowGeneratorBase):
             spotlight_size: float = 0.3,
             spotlight_path_extension_factor: float = 0.5,
             dim_opacity: float = 0.2,
+            speed_in_px_per_second: float = None,
+            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
@@ -22,7 +24,9 @@ class SpotlightFlowArrowGenerator(AnimatedArrowGeneratorBase):
             width=width,
             height=height,
             speed=speed,
-            num_arrows=num_arrows
+            num_arrows=num_arrows,
+            speed_in_px_per_second=speed_in_px_per_second,
+            speed_in_duration_seconds=speed_in_duration_seconds
         )
         self.direction = direction.lower()
         self.spotlight_size = max(0.1, min(1.0, spotlight_size))
@@ -171,12 +175,11 @@ class SpotlightFlowArrowGenerator(AnimatedArrowGeneratorBase):
         else:
             raise ValueError(f"Invalid direction: {self.direction}. Use 'up', 'down', 'left', or 'right'.")
 
-    def _calculate_animation_duration(self) -> float:
+    def _get_transform_distance(self) -> float:
         if self.direction in ["up", "down"]:
-            total_distance = self.height
+            return float(self.height)
         else:
-            total_distance = self.width
-        return total_distance / self.speed
+            return float(self.width)
 
     def _generate_animations(self) -> str:
         distance = max(self.width, self.height)

--- a/captain_arro/generators/spread/bouncing_spread_arrow_generator.py
+++ b/captain_arro/generators/spread/bouncing_spread_arrow_generator.py
@@ -9,23 +9,21 @@ class BouncingSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             stroke_width: int = 2,
             width: int = 300,
             height: int = 150,
-            speed: float = 10.0,
+            speed_in_px_per_second: float = 10.0,
+            speed_in_duration_seconds: float = None,
             direction: SPREAD_DIRECTIONS = "vertical",
             num_arrows: int = 6,
             animation: ANIMATION_TYPES = "ease-in-out",
             center_gap_ratio: float = 0.2,
-            speed_in_px_per_second: float = None,
-            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
             stroke_width=stroke_width,
             width=width,
             height=height,
-            speed=speed,
-            num_arrows=max(2, num_arrows),
             speed_in_px_per_second=speed_in_px_per_second,
-            speed_in_duration_seconds=speed_in_duration_seconds
+            speed_in_duration_seconds=speed_in_duration_seconds,
+            num_arrows=max(2, num_arrows),
         )
         self.direction = direction.lower()
         self.animation = animation
@@ -55,19 +53,19 @@ class BouncingSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             }}
 
             .group-left {{
-              animation: moveLeft {self._calculate_animation_duration():.2f}s {self.animation} infinite alternate;
+              animation: moveLeft {self.speed_in_duration_seconds:.2f}s {self.animation} infinite alternate;
             }}
 
             .group-right {{
-              animation: moveRight {self._calculate_animation_duration():.2f}s {self.animation} infinite alternate;
+              animation: moveRight {self.speed_in_duration_seconds:.2f}s {self.animation} infinite alternate;
             }}
 
             .group-top {{
-              animation: moveTop {self._calculate_animation_duration():.2f}s {self.animation} infinite alternate;
+              animation: moveTop {self.speed_in_duration_seconds:.2f}s {self.animation} infinite alternate;
             }}
 
             .group-bottom {{
-              animation: moveBottom {self._calculate_animation_duration():.2f}s {self.animation} infinite alternate;
+              animation: moveBottom {self.speed_in_duration_seconds:.2f}s {self.animation} infinite alternate;
             }}
 
             {animations}

--- a/captain_arro/generators/spread/bouncing_spread_arrow_generator.py
+++ b/captain_arro/generators/spread/bouncing_spread_arrow_generator.py
@@ -14,6 +14,8 @@ class BouncingSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             num_arrows: int = 6,
             animation: ANIMATION_TYPES = "ease-in-out",
             center_gap_ratio: float = 0.2,
+            speed_in_px_per_second: float = None,
+            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
@@ -21,7 +23,9 @@ class BouncingSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             width=width,
             height=height,
             speed=speed,
-            num_arrows=max(2, num_arrows)
+            num_arrows=max(2, num_arrows),
+            speed_in_px_per_second=speed_in_px_per_second,
+            speed_in_duration_seconds=speed_in_duration_seconds
         )
         self.direction = direction.lower()
         self.animation = animation
@@ -272,17 +276,14 @@ class BouncingSpreadArrowGenerator(AnimatedArrowGeneratorBase):
         offset_y = layout["arrow_height"] // 2
         return f"{-offset_x},{-offset_y} 0,{offset_y} {offset_x},{-offset_y}"
 
-    def _get_transform_distance(self) -> int:
+    def _get_transform_distance(self) -> float:
         if self.direction == "vertical":
             available_space = self.height - 2 * (self.height // 8)
-            return int(available_space * 0.15)
+            return float(available_space * 0.15)
         else:
             available_space = self.width - 2 * (self.width // 8)
-            return int(available_space * 0.15)
+            return float(available_space * 0.15)
 
-    def _calculate_animation_duration(self) -> float:
-        transform_distance = self._get_transform_distance()
-        return transform_distance / self.speed
 
     def _generate_animations(self) -> str:
         distance = self._get_transform_distance()

--- a/captain_arro/generators/spread/spotlight_spread_arrow_generator.py
+++ b/captain_arro/generators/spread/spotlight_spread_arrow_generator.py
@@ -9,25 +9,23 @@ class SpotlightSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             stroke_width: int = 10,
             width: int = 100,
             height: int = 100,
-            speed: float = 20.0,
+            speed_in_px_per_second: float = 20.0,
+            speed_in_duration_seconds: float = None,
             direction: SPREAD_DIRECTIONS = "horizontal",
             num_arrows: int = 4,
             spotlight_size: float = 0.3,
             spotlight_path_extension_factor: float = 0.5,
             dim_opacity: float = 0.2,
             center_gap_ratio: float = 0.2,
-            speed_in_px_per_second: float = None,
-            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
             stroke_width=stroke_width,
             width=width,
             height=height,
-            speed=speed,
-            num_arrows=max(2, num_arrows),
             speed_in_px_per_second=speed_in_px_per_second,
-            speed_in_duration_seconds=speed_in_duration_seconds
+            speed_in_duration_seconds=speed_in_duration_seconds,
+            num_arrows=max(2, num_arrows),
         )
         self.direction = direction.lower()
         self.spotlight_size = max(0.1, min(1.0, spotlight_size))
@@ -94,7 +92,7 @@ class SpotlightSpreadArrowGenerator(AnimatedArrowGeneratorBase):
         """
 
     def _generate_gradient_defs(self) -> str:
-        duration = self._calculate_animation_duration()
+        duration = self.speed_in_duration_seconds
         spotlight_percent = self.spotlight_size * 100
         dim_before = (100 - spotlight_percent) / 2
         dim_after = dim_before + spotlight_percent

--- a/captain_arro/generators/spread/spotlight_spread_arrow_generator.py
+++ b/captain_arro/generators/spread/spotlight_spread_arrow_generator.py
@@ -16,6 +16,8 @@ class SpotlightSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             spotlight_path_extension_factor: float = 0.5,
             dim_opacity: float = 0.2,
             center_gap_ratio: float = 0.2,
+            speed_in_px_per_second: float = None,
+            speed_in_duration_seconds: float = None,
     ):
         super().__init__(
             color=color,
@@ -23,7 +25,9 @@ class SpotlightSpreadArrowGenerator(AnimatedArrowGeneratorBase):
             width=width,
             height=height,
             speed=speed,
-            num_arrows=max(2, num_arrows)
+            num_arrows=max(2, num_arrows),
+            speed_in_px_per_second=speed_in_px_per_second,
+            speed_in_duration_seconds=speed_in_duration_seconds
         )
         self.direction = direction.lower()
         self.spotlight_size = max(0.1, min(1.0, spotlight_size))
@@ -344,12 +348,11 @@ class SpotlightSpreadArrowGenerator(AnimatedArrowGeneratorBase):
         offset_y = layout["arrow_height"] // 2
         return f"{-offset_x},{-offset_y} 0,{offset_y} {offset_x},{-offset_y}"
 
-    def _calculate_animation_duration(self) -> float:
+    def _get_transform_distance(self) -> float:
         if self.direction == "vertical":
-            total_distance = self.height
+            return float(self.height)
         else:
-            total_distance = self.width
-        return total_distance / self.speed
+            return float(self.width)
 
     def _generate_animations(self) -> str:
         """Return empty string since animations are handled by gradient transforms."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -42,7 +42,7 @@ class TestAnimatedArrowGeneratorBase:
         assert generator.stroke_width == 10
         assert generator.width == 100
         assert generator.height == 100
-        assert generator.speed == 20.0
+        assert generator.speed_in_px_per_second == 20.0
         assert generator.num_arrows == 4
 
     def test_init_custom_values(self):
@@ -52,7 +52,7 @@ class TestAnimatedArrowGeneratorBase:
             stroke_width=15,
             width=200,
             height=150,
-            speed=30.0,
+            speed_in_px_per_second=30.0,
             num_arrows=6
         )
         
@@ -60,7 +60,7 @@ class TestAnimatedArrowGeneratorBase:
         assert generator.stroke_width == 15
         assert generator.width == 200
         assert generator.height == 150
-        assert generator.speed == 30.0
+        assert generator.speed_in_px_per_second == 30.0
         assert generator.num_arrows == 6
 
     def test_num_arrows_validation(self):

--- a/tests/test_moving_flow_arrow_generator.py
+++ b/tests/test_moving_flow_arrow_generator.py
@@ -17,7 +17,7 @@ class TestMovingFlowArrowGenerator:
         assert generator.stroke_width == 15
         assert generator.width == 100
         assert generator.height == 100
-        assert generator.speed == 20.0
+        assert generator.speed_in_px_per_second == 20.0
         assert generator.direction == "right"
         assert generator.num_arrows == 4
         assert generator.animation == "ease-in-out"
@@ -29,7 +29,7 @@ class TestMovingFlowArrowGenerator:
             stroke_width=20,
             width=200,
             height=150,
-            speed=30.0,
+            speed_in_px_per_second=30.0,
             direction="up",
             num_arrows=6,
             animation="linear"
@@ -39,7 +39,7 @@ class TestMovingFlowArrowGenerator:
         assert generator.stroke_width == 20
         assert generator.width == 200
         assert generator.height == 150
-        assert generator.speed == 30.0
+        assert generator.speed_in_px_per_second == 30.0
         assert generator.direction == "up"
         assert generator.num_arrows == 6
         assert generator.animation == "linear"
@@ -102,7 +102,7 @@ class TestMovingFlowArrowGenerator:
 
     def test_calculate_animation_duration(self):
         """Test animation duration calculation."""
-        generator = MovingFlowArrowGenerator(speed=20.0, width=100, height=100)
+        generator = MovingFlowArrowGenerator(speed_in_px_per_second=20.0, width=100, height=100)
         duration = generator._calculate_animation_duration()
         
         assert isinstance(duration, float)


### PR DESCRIPTION
  - ✅ Added speed_in_px_per_second and speed_in_duration_seconds parameters to all generators
  - ✅ Implemented validation to ensure only one speed option is defined
  - ✅ Added abstract _get_transform_distance method to base class
  - ✅ Updated all generator subclasses to support the new speed options

The implementation allows users to specify speed in two new ways:
  # Option 1: Speed in pixels per second
  gen = MovingFlowArrowGenerator(speed_in_px_per_second=50.0)

  # Option 2: Fixed duration in seconds  
  gen = MovingFlowArrowGenerator(speed_in_duration_seconds=2.5)
