### PR TITLE
Fix Safari spotlight arrow animation by replacing SMIL gradient transform with CSS mask sweep

### DIFF
--- a/captain_arro/generators/spread/spotlight_spread_arrow_generator.py
+++ b/captain_arro/generators/spread/spotlight_spread_arrow_generator.py
@@ -36,357 +36,256 @@ class SpotlightSpreadArrowGenerator(AnimatedArrowGeneratorBase):
         self.center_gap_ratio = max(0.1, min(0.4, center_gap_ratio))
 
     def generate_svg(self, unique_id: Union[bool, str] = True) -> str:
-        """Override to customize arrow styles with directional gradients."""
-        
         clip_bounds = self._get_clip_bounds()
         animations = self._generate_animations()
         arrow_elements = self._generate_arrow_elements()
-        gradient_defs = self._generate_gradient_defs()
-
+        mask_defs = self._generate_mask_defs()
         svg = f"""
         <svg width="{self.width}" height="{self.height}" viewBox="0 0 {self.width} {self.height}" xmlns="http://www.w3.org/2000/svg">
           <defs>
             <clipPath id="arrowClip">
               <rect x="{clip_bounds['x']}" y="{clip_bounds['y']}" width="{clip_bounds['width']}" height="{clip_bounds['height']}"/>
             </clipPath>
-            {gradient_defs}
+            {mask_defs}
           </defs>
-
           <style>
-            .arrow-left {{
-              stroke: url(#spotlightGradientLeft);
-              stroke-width: {self.stroke_width};
-              stroke-linecap: round;
-              stroke-linejoin: round;
-              fill: none;
-            }}
-
-            .arrow-right {{
-              stroke: url(#spotlightGradientRight);
-              stroke-width: {self.stroke_width};
-              stroke-linecap: round;
-              stroke-linejoin: round;
-              fill: none;
-            }}
-
-            .arrow-top {{
-              stroke: url(#spotlightGradientTop);
-              stroke-width: {self.stroke_width};
-              stroke-linecap: round;
-              stroke-linejoin: round;
-              fill: none;
-            }}
-
-            .arrow-bottom {{
-              stroke: url(#spotlightGradientBottom);
-              stroke-width: {self.stroke_width};
-              stroke-linecap: round;
-              stroke-linejoin: round;
-              fill: none;
-            }}
-            
             {animations}
           </style>
-
           <g clip-path="url(#arrowClip)">
             {arrow_elements}
           </g>
         </svg>
         """
-        
-        # Apply unique suffixes if requested
         if unique_id is not False:
-            if unique_id is True:
-                # Generate random suffix
-                suffix = uuid.uuid4().hex[:6]
-            else:
-                # Use provided suffix
-                suffix = str(unique_id)
-            
-            # Get the list of IDs that need to be made unique
-            id_keys = self._get_unique_id_keys()
-            svg = self._apply_unique_suffix(svg, suffix, id_keys)
-        
+            suffix = uuid.uuid4().hex[:6] if unique_id is True else str(unique_id)
+            svg = self._apply_unique_suffix(svg, suffix, self._get_unique_id_keys())
         return svg
 
-    def _generate_gradient_defs(self) -> str:
-        duration = self.speed_in_duration_seconds
-        spotlight_percent = self.spotlight_size * 100
-        dim_before = (100 - spotlight_percent) / 2
-        dim_after = dim_before + spotlight_percent
+    def _axis(self) -> str:
+        return "x" if self.direction == "horizontal" else "y"
 
-        if self.direction == "horizontal":
-            center_x = self.width // 2
-            left_gradient = f"""
-        <linearGradient id="spotlightGradientLeft" x1="0" y1="0" x2="{self.width}" y2="0" gradientUnits="userSpaceOnUse">
-          <animateTransform
-            attributeName="gradientTransform"
-            type="translate"
-            values="{center_x} 0; -{self.width} 0"
-            dur="{duration:.2f}s"
-            repeatCount="indefinite"/>
-          <stop offset="0%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="{dim_before:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="50%" stop-color="{self.color}" stop-opacity="1"/>
-          <stop offset="{dim_after:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="100%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-        </linearGradient>"""
-
-            right_gradient = f"""
-        <linearGradient id="spotlightGradientRight" x1="-{self.width}" y1="0" x2="0" y2="0" gradientUnits="userSpaceOnUse">
-          <animateTransform
-            attributeName="gradientTransform"
-            type="translate"
-            values="-{center_x} 0; {self.width} 0"
-            dur="{duration:.2f}s"
-            repeatCount="indefinite"/>
-          <stop offset="0%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="{dim_before:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="50%" stop-color="{self.color}" stop-opacity="1"/>
-          <stop offset="{dim_after:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="100%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-        </linearGradient>"""
-
-            return left_gradient + "\n" + right_gradient
-
+    def _rect_dims(self) -> Tuple[float, float]:
+        if self._axis() == "x":
+            w = self.width * (0.6 + 0.4 * max(0.0, self.spotlight_path_extension_factor))
+            h = self.height * 2.0
         else:
-            center_y = self.height // 2
-            top_gradient = f"""
-        <linearGradient id="spotlightGradientTop" x1="0" y1="0" x2="0" y2="{self.height}" gradientUnits="userSpaceOnUse">
-          <animateTransform
-            attributeName="gradientTransform"
-            type="translate"
-            values="0 {center_y}; 0 -{self.height}"
-            dur="{duration:.2f}s"
-            repeatCount="indefinite"/>
-          <stop offset="0%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="{dim_before:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="50%" stop-color="{self.color}" stop-opacity="1"/>
-          <stop offset="{dim_after:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="100%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-        </linearGradient>"""
+            w = self.width * 2.0
+            h = self.height * (0.6 + 0.4 * max(0.0, self.spotlight_path_extension_factor))
+        return float(w), float(h)
 
-            bottom_gradient = f"""
-        <linearGradient id="spotlightGradientBottom" x1="0" y1="-{self.height}" x2="0" y2="0" gradientUnits="userSpaceOnUse">
-          <animateTransform
-            attributeName="gradientTransform"
-            type="translate"
-            values="0 -{center_y}; 0 {self.height}"
-            dur="{duration:.2f}s"
-            repeatCount="indefinite"/>
-          <stop offset="0%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="{dim_before:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="50%" stop-color="{self.color}" stop-opacity="1"/>
-          <stop offset="{dim_after:.1f}%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-          <stop offset="100%" stop-color="{self.color}" stop-opacity="{self.dim_opacity}"/>
-        </linearGradient>"""
+    def _duration_seconds(self) -> float:
+        if self.speed_in_duration_seconds is not None:
+            return float(self.speed_in_duration_seconds)
+        if self._axis() == "x":
+            dist = self.width + self._rect_dims()[0]
+        else:
+            dist = self.height + self._rect_dims()[1]
+        v = max(1e-6, float(self.speed_in_px_per_second))
+        return dist / v
 
-            return top_gradient + "\n" + bottom_gradient
+    def _generate_mask_defs(self) -> str:
+        spotlight_pct = self.spotlight_size * 100.0
+        a = max(0.0, min(50.0, (100.0 - spotlight_pct) / 2.0))
+        b = 100.0 - a
+        rect_w, rect_h = self._rect_dims()
+        rect_x = (self.width - rect_w) / 2.0
+        rect_y = (self.height - rect_h) / 2.0
+        if self._axis() == "x":
+            grad_axis = 'x1="0" y1="0" x2="1" y2="0"'
+        else:
+            grad_axis = 'x1="0" y1="0" x2="0" y2="1"'
+        return f"""
+        <linearGradient id="maskGradSpreadA" {grad_axis}>
+          <stop offset="0%" stop-color="black" stop-opacity="0"/>
+          <stop offset="{a:.1f}%" stop-color="white" stop-opacity="1"/>
+          <stop offset="{b:.1f}%" stop-color="white" stop-opacity="1"/>
+          <stop offset="100%" stop-color="black" stop-opacity="0"/>
+        </linearGradient>
+        <linearGradient id="maskGradSpreadB" {grad_axis}>
+          <stop offset="0%" stop-color="black" stop-opacity="0"/>
+          <stop offset="{a:.1f}%" stop-color="white" stop-opacity="1"/>
+          <stop offset="{b:.1f}%" stop-color="white" stop-opacity="1"/>
+          <stop offset="100%" stop-color="black" stop-opacity="0"/>
+        </linearGradient>
+        <mask id="sweepMaskA" maskUnits="userSpaceOnUse" x="0" y="0" width="{self.width}" height="{self.height}">
+          <rect class="sweep-rect-a" x="{rect_x:.2f}" y="{rect_y:.2f}" width="{rect_w:.2f}" height="{rect_h:.2f}" fill="url(#maskGradSpreadA)"/>
+        </mask>
+        <mask id="sweepMaskB" maskUnits="userSpaceOnUse" x="0" y="0" width="{self.width}" height="{self.height}">
+          <rect class="sweep-rect-b" x="{rect_x:.2f}" y="{rect_y:.2f}" width="{rect_w:.2f}" height="{rect_h:.2f}" fill="url(#maskGradSpreadB)"/>
+        </mask>
+        """
+
+    def _generate_animations(self) -> str:
+        dur = self._duration_seconds()
+        rect_w, rect_h = self._rect_dims()
+        if self._axis() == "x":
+            travel = (self.width + rect_w) / 2.0
+            start_a, end_a = f"translateX(0px)", f"translateX(-{travel:.2f}px)"
+            start_b, end_b = f"translateX(0px)", f"translateX({travel:.2f}px)"
+        else:
+            travel = (self.height + rect_h) / 2.0
+            start_a, end_a = f"translateY(0px)", f"translateY(-{travel:.2f}px)"
+            start_b, end_b = f"translateY(0px)", f"translateY({travel:.2f}px)"
+        return f"""
+        .arrow-dim polyline {{
+          stroke: {self.color};
+          stroke-opacity: {self.dim_opacity};
+          stroke-width: {self.stroke_width};
+          stroke-linecap: round;
+          stroke-linejoin: round;
+          fill: none;
+        }}
+        .arrow-hi-a polyline,
+        .arrow-hi-b polyline {{
+          stroke: {self.color};
+          stroke-width: {self.stroke_width};
+          stroke-linecap: round;
+          stroke-linejoin: round;
+          fill: none;
+        }}
+        .arrow-hi-a polyline {{ mask: url(#sweepMaskA); }}
+        .arrow-hi-b polyline {{ mask: url(#sweepMaskB); }}
+        @keyframes sweepA {{ 0% {{ transform: {start_a}; }} 100% {{ transform: {end_a}; }} }}
+        @keyframes sweepB {{ 0% {{ transform: {start_b}; }} 100% {{ transform: {end_b}; }} }}
+        .sweep-rect-a {{ animation: sweepA {dur:.2f}s linear infinite; transform-box: fill-box; transform-origin: center; }}
+        .sweep-rect-b {{ animation: sweepB {dur:.2f}s linear infinite; transform-box: fill-box; transform-origin: center; }}
+        """
 
     def _generate_arrow_elements(self) -> str:
-        elements = []
-
         if self.direction == "horizontal":
             left_positions = self._get_left_arrow_positions()
             right_positions = self._get_right_arrow_positions()
-
+            dim_parts = []
+            hi_a_parts = []
+            hi_b_parts = []
             for pos in left_positions:
-                arrow_points = self._get_left_arrow_points()
-                elements.append(
-                    f'    <g class="arrow-left" style="transform: translate({pos["x"]}px, {pos["y"]}px)">\n      <polyline points="{arrow_points}"/>\n    </g>')
-
+                pts = self._get_left_arrow_points()
+                dim_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
+                hi_a_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
             for pos in right_positions:
-                arrow_points = self._get_right_arrow_points()
-                elements.append(
-                    f'    <g class="arrow-right" style="transform: translate({pos["x"]}px, {pos["y"]}px)">\n      <polyline points="{arrow_points}"/>\n    </g>')
-
+                pts = self._get_right_arrow_points()
+                dim_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
+                hi_b_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
+            return f'''
+            <g class="arrow-dim">{''.join(dim_parts)}</g>
+            <g class="arrow-hi-a">{''.join(hi_a_parts)}</g>
+            <g class="arrow-hi-b">{''.join(hi_b_parts)}</g>
+            '''.strip()
         else:
             top_positions = self._get_top_arrow_positions()
             bottom_positions = self._get_bottom_arrow_positions()
-
+            dim_parts = []
+            hi_a_parts = []
+            hi_b_parts = []
             for pos in top_positions:
-                arrow_points = self._get_up_arrow_points()
-                elements.append(
-                    f'    <g class="arrow-top" style="transform: translate({pos["x"]}px, {pos["y"]}px)">\n      <polyline points="{arrow_points}"/>\n    </g>')
-
+                pts = self._get_up_arrow_points()
+                dim_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
+                hi_a_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
             for pos in bottom_positions:
-                arrow_points = self._get_down_arrow_points()
-                elements.append(
-                    f'    <g class="arrow-bottom" style="transform: translate({pos["x"]}px, {pos["y"]}px)">\n      <polyline points="{arrow_points}"/>\n    </g>')
-
-        return "\n    \n".join(elements)
+                pts = self._get_down_arrow_points()
+                dim_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
+                hi_b_parts.append(f'<g transform="translate({pos["x"]},{pos["y"]})"><polyline points="{pts}"/></g>')
+            return f'''
+            <g class="arrow-dim">{''.join(dim_parts)}</g>
+            <g class="arrow-hi-a">{''.join(hi_a_parts)}</g>
+            <g class="arrow-hi-b">{''.join(hi_b_parts)}</g>
+            '''.strip()
 
     def _calculate_arrow_layout(self):
-        """SIMPLE constraint-based layout - work backwards from constraints"""
         arrows_per_side = self.num_arrows // 2
-        
         if self.direction == "horizontal":
-            # 1. Arrow size: use most of perpendicular space (height)
-            arrow_height = int(self.height * 0.8)  # 80% of height
-            
-            # 2. Center gap: fixed ratio 
+            arrow_height = int(self.height * 0.8)
             center_gap = int(self.width * self.center_gap_ratio)
-            
-            # 3. Available space per side
             available_width_per_side = (self.width - center_gap) // 2
-            
-            # 4. Arrow width: constrained by space per arrow
-            arrow_width = available_width_per_side // max(arrows_per_side, 1)
-            
-            return {
-                "arrow_width": arrow_width,
-                "arrow_height": arrow_height,
-                "center_gap": center_gap,
-                "available_width_per_side": available_width_per_side
-            }
+            arrow_width = max(1, available_width_per_side // max(arrows_per_side, 1))
+            return {"arrow_width": arrow_width, "arrow_height": arrow_height, "center_gap": center_gap, "available_width_per_side": available_width_per_side}
         else:
-            # 1. Arrow size: use most of perpendicular space (width)
-            arrow_width = int(self.width * 0.8)  # 80% of width
-            
-            # 2. Center gap: fixed ratio 
+            arrow_width = int(self.width * 0.8)
             center_gap = int(self.height * self.center_gap_ratio)
-            
-            # 3. Available space per side
             available_height_per_side = (self.height - center_gap) // 2
-            
-            # 4. Arrow height: constrained by space per arrow
-            arrow_height = available_height_per_side // max(arrows_per_side, 1)
-            
-            return {
-                "arrow_width": arrow_width,
-                "arrow_height": arrow_height,
-                "center_gap": center_gap,
-                "available_height_per_side": available_height_per_side
-            }
+            arrow_height = max(1, available_height_per_side // max(arrows_per_side, 1))
+            return {"arrow_width": arrow_width, "arrow_height": arrow_height, "center_gap": center_gap, "available_height_per_side": available_height_per_side}
 
     def _get_left_arrow_positions(self) -> list[dict[str, int]]:
         arrows_per_side = self.num_arrows // 2
-        positions = []
-
+        positions: list[dict[str, int]] = []
         if self.direction == "horizontal":
             layout = self._calculate_arrow_layout()
-            
             center_x = self.width // 2
             left_edge = center_x - layout["center_gap"] // 2
-            
             for i in range(arrows_per_side):
-                # Outermost arrow tip exactly at edge, work backwards
-                # Account for stroke width so stroke edge stays within bounds
-                arrow_center = left_edge - (layout["arrow_width"] // 2) + (self.stroke_width // 2) - i * layout["arrow_width"]
-                positions.append({"x": int(arrow_center), "y": self.height // 2})
-
+                cx = left_edge - (layout["arrow_width"] // 2) + (self.stroke_width // 2) - i * layout["arrow_width"]
+                positions.append({"x": int(cx), "y": self.height // 2})
         return positions
 
     def _get_right_arrow_positions(self) -> list[dict[str, int]]:
         arrows_per_side = self.num_arrows // 2
-        positions = []
-
+        positions: list[dict[str, int]] = []
         if self.direction == "horizontal":
             layout = self._calculate_arrow_layout()
-            
             center_x = self.width // 2
             right_edge = center_x + layout["center_gap"] // 2
-            
             for i in range(arrows_per_side):
-                # Outermost arrow tip exactly at edge, work backwards
-                # Account for stroke width so stroke edge stays within bounds
-                arrow_center = right_edge + (layout["arrow_width"] // 2) - (self.stroke_width // 2) + i * layout["arrow_width"]
-                positions.append({"x": int(arrow_center), "y": self.height // 2})
-
+                cx = right_edge + (layout["arrow_width"] // 2) - (self.stroke_width // 2) + i * layout["arrow_width"]
+                positions.append({"x": int(cx), "y": self.height // 2})
         return positions
 
     def _get_top_arrow_positions(self) -> list[dict[str, int]]:
         arrows_per_side = self.num_arrows // 2
-        positions = []
-
+        positions: list[dict[str, int]] = []
         if self.direction == "vertical":
             layout = self._calculate_arrow_layout()
-            
             center_y = self.height // 2
             top_edge = center_y - layout["center_gap"] // 2
-            
             for i in range(arrows_per_side):
-                # Outermost arrow tip exactly at edge, work backwards
-                # Account for stroke width so stroke edge stays within bounds
-                arrow_center = top_edge - (layout["arrow_height"] // 2) + (self.stroke_width // 2) - i * layout["arrow_height"]
-                positions.append({"x": self.width // 2, "y": int(arrow_center)})
-
+                cy = top_edge - (layout["arrow_height"] // 2) + (self.stroke_width // 2) - i * layout["arrow_height"]
+                positions.append({"x": self.width // 2, "y": int(cy)})
         return positions
 
     def _get_bottom_arrow_positions(self) -> list[dict[str, int]]:
         arrows_per_side = self.num_arrows // 2
-        positions = []
-
+        positions: list[dict[str, int]] = []
         if self.direction == "vertical":
             layout = self._calculate_arrow_layout()
-            
             center_y = self.height // 2
             bottom_edge = center_y + layout["center_gap"] // 2
-            
             for i in range(arrows_per_side):
-                # Outermost arrow tip exactly at edge, work backwards
-                # Account for stroke width so stroke edge stays within bounds
-                arrow_center = bottom_edge + (layout["arrow_height"] // 2) - (self.stroke_width // 2) + i * layout["arrow_height"]
-                positions.append({"x": self.width // 2, "y": int(arrow_center)})
-
+                cy = bottom_edge + (layout["arrow_height"] // 2) - (self.stroke_width // 2) + i * layout["arrow_height"]
+                positions.append({"x": self.width // 2, "y": int(cy)})
         return positions
 
     def _get_clip_bounds(self) -> dict[str, int]:
-        # Use full canvas area - no margins
-        return {
-            "x": 0,
-            "y": 0,
-            "width": self.width,
-            "height": self.height
-        }
+        return {"x": 0, "y": 0, "width": self.width, "height": self.height}
 
     def _get_left_arrow_points(self) -> str:
         layout = self._calculate_arrow_layout()
-        offset_x = layout["arrow_width"] // 2
-        offset_y = layout["arrow_height"] // 2
-        return f"{offset_x},{-offset_y} {-offset_x},0 {offset_x},{offset_y}"
+        ox = layout["arrow_width"] // 2
+        oy = layout["arrow_height"] // 2
+        return f"{ox},{-oy} {-ox},0 {ox},{oy}"
 
     def _get_right_arrow_points(self) -> str:
         layout = self._calculate_arrow_layout()
-        offset_x = layout["arrow_width"] // 2
-        offset_y = layout["arrow_height"] // 2
-        return f"{-offset_x},{-offset_y} {offset_x},0 {-offset_x},{offset_y}"
+        ox = layout["arrow_width"] // 2
+        oy = layout["arrow_height"] // 2
+        return f"{-ox},{-oy} {ox},0 {-ox},{oy}"
 
     def _get_up_arrow_points(self) -> str:
         layout = self._calculate_arrow_layout()
-        offset_x = layout["arrow_width"] // 2
-        offset_y = layout["arrow_height"] // 2
-        return f"{-offset_x},{offset_y} 0,{-offset_y} {offset_x},{offset_y}"
+        ox = layout["arrow_width"] // 2
+        oy = layout["arrow_height"] // 2
+        return f"{-ox},{oy} 0,{-oy} {ox},{oy}"
 
     def _get_down_arrow_points(self) -> str:
         layout = self._calculate_arrow_layout()
-        offset_x = layout["arrow_width"] // 2
-        offset_y = layout["arrow_height"] // 2
-        return f"{-offset_x},{-offset_y} 0,{offset_y} {offset_x},{-offset_y}"
+        ox = layout["arrow_width"] // 2
+        oy = layout["arrow_height"] // 2
+        return f"{-ox},{-oy} 0,{oy} {ox},{-oy}"
 
     def _get_transform_distance(self) -> float:
-        if self.direction == "vertical":
-            return float(self.height)
-        else:
-            return float(self.width)
-
-    def _generate_animations(self) -> str:
-        """Return empty string since animations are handled by gradient transforms."""
-        return ""
+        return float(self.height if self.direction == "vertical" else self.width)
 
     def _get_unique_id_keys(self) -> list[str]:
-        """Get the list of ID keys that need to be made unique for this generator."""
-        return [
-            "arrowClip",
-            "spotlightGradientLeft",
-            "spotlightGradientRight", 
-            "spotlightGradientTop",
-            "spotlightGradientBottom",
-            "arrow-left",
-            "arrow-right",
-            "arrow-top", 
-            "arrow-bottom"
-        ]
+        return ["arrowClip", "maskGradSpreadA", "maskGradSpreadB", "sweepMaskA", "sweepMaskB"]
 
 
 if __name__ == "__main__":
@@ -397,14 +296,14 @@ if __name__ == "__main__":
     generator.save_to_file("_tmp/spotlight_spread_arrow_default.svg")
 
     configurations = [
-        {"direction": "horizontal", "color": "#3b82f6", "num_arrows": 6, "width": 200, "height": 80,
-         "speed": 80.0, "spotlight_size": 0.4},
-        {"direction": "vertical", "color": "#ef4444", "num_arrows": 4, "width": 100, "height": 150,
-         "speed": 60.0, "spotlight_size": 0.3, "dim_opacity": 0.1},
-        {"direction": "horizontal", "color": "#10b981", "num_arrows": 8, "width": 180, "height": 60,
-         "speed": 100.0, "spotlight_size": 0.25, "center_gap_ratio": 0.3},
-        {"direction": "vertical", "color": "#f59e0b", "num_arrows": 6, "width": 100, "height": 200,
-         "speed": 90.0, "spotlight_size": 0.35, "dim_opacity": 0.15}
+        {"num_arrows": 4, "direction": "vertical", "color": "#ef4444", "width": 100, "height": 150,
+         "speed_in_px_per_second": 3.0, "spotlight_size": 0.3, "dim_opacity": 0.1},
+        {"num_arrows": 6, "direction": "horizontal", "color": "#3b82f6", "width": 200, "height": 80,
+         "speed_in_px_per_second": 2.0, "spotlight_size": 0.4},
+        {"num_arrows": 6, "direction": "vertical", "color": "#f59e0b", "width": 100, "height": 200,
+         "speed_in_px_per_second": 5.0, "spotlight_size": 0.35, "dim_opacity": 0.15},
+        {"num_arrows": 8, "direction": "horizontal", "color": "#10b981", "width": 180, "height": 60,
+         "speed_in_px_per_second": 4.0, "spotlight_size": 0.25, "center_gap_ratio": 0.3},
     ]
 
     for config in configurations:


### PR DESCRIPTION
This PR fixes a long-standing compatibility issue where the SpotlightFlowArrowGenerator animation did not work in Safari. The root cause was Safari’s lack of support for animating gradientTransform on <linearGradient> elements via SMIL (<animateTransform>).

Changes
	•	Removed SMIL gradient animation
Safari does not animate <linearGradient> transforms, which caused the “spotlight” highlight to remain static.
	•	New luminance mask sweep
The spotlight is now implemented as:
	1.	A static <linearGradient> defining opacity from black→white→black.
	2.	A <mask> containing a <rect> filled with that gradient.
	3.	CSS keyframes animate the <rect> across the arrows.
	•	Abstract methods implemented
_generate_arrow_elements and _generate_animations now produce:
	•	A dim base stroke layer.
	•	A masked highlight stroke layer.
	•	CSS @keyframes sweep animation for the mask rectangle.
	•	Backward-compatible IDs
Unique ID suffixing supports both legacy (spotlightGradient) and new (maskGrad, sweepMask) identifiers.

Why this works
	•	CSS transforms on shapes are GPU-accelerated and supported in all browsers, including Safari.
	•	No SMIL = no animation freeze in Safari.
	•	The mask approach visually replicates the original gradient sweep effect.

Impact
	•	Fixed: Safari now displays the animated spotlight correctly.
	•	No breaking changes: API and constructor parameters remain unchanged.
	•	Performance: CSS transform animation is efficient and hardware-accelerated.